### PR TITLE
Move relative styles at the end

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export default function(styleApi: IStyleAPI): Array<IStyleItem> {
         {separator: true},
 
         // import "./foo"
-        {match: and(hasNoMember, isRelativeModule)},
+        {match: and(hasNoMember, isRelativeModule, not(isStylesModule))},
         {separator: true},
 
         // import React from "react";
@@ -69,7 +69,10 @@ export default function(styleApi: IStyleAPI): Array<IStyleItem> {
         },
         {separator: true},
 
-        // import styles from "./Components.scss";
+	// import "./styles";
+        {match: and(hasNoMember, isRelativeModule, isStylesModule)},
+
+	// import styles from "./Components.scss";
         {match: isStylesModule, sort: [dotSegmentCount, moduleName(naturally)], sortNamedMembers: alias(unicode)},
         {separator: true},
         {separator: true},

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export default function(styleApi: IStyleAPI): Array<IStyleItem> {
         },
         {separator: true},
 
-	// import "./styles";
+	// import "./styles.css";
         {match: and(hasNoMember, isRelativeModule, isStylesModule)},
 
 	// import styles from "./Components.scss";


### PR DESCRIPTION
This pull request changes the sorting order for relative style modules. It moves the style modules at the end just before other style modules.